### PR TITLE
Update NoiseLabsNuSOAPExtension.php

### DIFF
--- a/DependencyInjection/NoiseLabsNuSOAPExtension.php
+++ b/DependencyInjection/NoiseLabsNuSOAPExtension.php
@@ -56,6 +56,6 @@ class NoiseLabsNuSOAPExtension extends Extension
      */
     public function getAlias()
     {
-        return 'noiselabs_nusoap';
+        return 'noise_labs_nu_soap';
     }
 }


### PR DESCRIPTION
Because of the CamelCase-to-Underscore convention, if you don't make this change, it throws

[RuntimeException]
An error occurred when executing the ""cache:clear --no-warmup"" command.

[LogicException]
Users will expect the alias of the default extension of a bundle to be the
underscored version of the bundle name ("noise_labs_nu_soap"). You can over
ride "Bundle::getContainerExtension()" if you want to use "noiselabs_nusoap
" or another alias.