### PR TITLE
Comply with Symfony2 alias conventions

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -43,7 +43,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('noiselabs_nusoap');
+        $treeBuilder->root('noise_labs_nu_soap');
 
         return $treeBuilder;
     }

--- a/DependencyInjection/NoiseLabsNuSOAPExtension.php
+++ b/DependencyInjection/NoiseLabsNuSOAPExtension.php
@@ -56,6 +56,6 @@ class NoiseLabsNuSOAPExtension extends Extension
      */
     public function getAlias()
     {
-        return 'noiselabs_nusoap';
+        return 'noise_labs_nu_soap';
     }
 }

--- a/Tests/DependencyInjection/NoiseLabsNuSOAPExtensionTest.php
+++ b/Tests/DependencyInjection/NoiseLabsNuSOAPExtensionTest.php
@@ -37,14 +37,14 @@ class NoiseLabsNuSOAPExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $extension = new NoiseLabsNuSOAPExtension();
 
-        $this->assertEquals('noiselabs_nusoap', $extension->getAlias());
+        $this->assertEquals('noise_labs_nu_soap', $extension->getAlias());
     }
 
     public function testLoadFromExtension()
     {
         $container = $this->createContainer();
         $container->registerExtension(new NoiseLabsNuSOAPExtension());
-        $container->loadFromExtension('noiselabs_nusoap', array());
+        $container->loadFromExtension('noise_labs_nu_soap', array());
     }
 
     /**


### PR DESCRIPTION
Because of the CamelCase-to-Underscore convention, the alias "noiselabs_nusoap" throws:

    [RuntimeException]
    An error occurred when executing the ""cache:clear --no-warmup"" command.

    [LogicException]
    Users will expect the alias of the default extension of a bundle to be the
    underscored version of the bundle name ("noise_labs_nu_soap"). You can over
    ride "Bundle::getContainerExtension()" if you want to use "noiselabs_nusoap"
    or another alias.
