### PR TITLE
Relax Composer constraints to allow for Symfony-3.0 installs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "~2.0",
+        "symfony/framework-bundle": "^2.0 || ^3.0",
         "fergusean/nusoap": "0.9.5"
     },
     "require-dev": {


### PR DESCRIPTION
Attempt to resolve https://github.com/noiselabs/NoiselabsNuSOAPBundle/issues/12
