### PR TITLE
update nusoap dependecy to support php 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ curl -s http://getcomposer.org/installer | php
 Open a command console, enter your project directory and execute the following command to download the latest stable
 version of this bundle:
 
-    $ composer require noiselabs/nusoap-bundle
+    $ composer require manoakys/nusoap-bundle
 
 
 ### 2. Enable the Bundle

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/framework-bundle": "^2.0 || ^3.0",
-        "fergusean/nusoap": "0.9.5"
+        "wooxo/nusoap": "~0.9.6"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/framework-bundle": "^2.0 || ^3.0",
-        "wooxo/nusoap": "~0.9.6"
+        "wooxo/nusoap": "^0.9.6"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,15 @@
 {
-    "name": "noiselabs/nusoap-bundle",
+    "name": "manoakys/nusoap-bundle",
     "type": "symfony-bundle",
-    "description": "Symfony2 bundle for NuSOAP - SOAP Toolkit for PHP",
-    "keywords": ["soap", "symfony", "noiselabs"],
-    "homepage": "https://github.com/noiselabs/NoiselabsNuSOAPBundle",
+    "description": "Symfony2/3 bundle for NuSOAP - SOAP Toolkit for PHP with PHP 7 support",
+    "keywords": ["soap", "symfony", "noiselabs", "manoakys"],
+    "homepage": "https://github.com/manoakys/NoiselabsNuSOAPBundle",
     "license": "LGPL-3.0",
     "authors": [
         {
-            "name": "Vítor Brandão",
-            "email": "vitor@noiselabs.org",
-            "homepage": "http://noiselabs.org"
+            "name": "Vaidotas Gaidelis",
+            "email": "user@manoakys.lt",
+            "homepage": "https://github.com/manoakys/NoiselabsNuSOAPBundle"
         }
     ],
     "require": {


### PR DESCRIPTION
When using PHP7, we get deprecated errors, as in php 7 you cannot use class named function as constructor. I have updated dependency to wooxo/nusoap as he forked and updated code to be compatible with PHP 7